### PR TITLE
Add order confirmation page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,7 @@ import Browse from "./pages/Browse";
 import Home from "./pages/Home";
 import Restaurant from "./pages/Restaurant";
 import Cart from "./pages/Cart";
+import OrderConfirmation from "./pages/OrderConfirmation";
 
 function App() {
   return (
@@ -12,6 +13,7 @@ function App() {
         <Route index element={<Home />} />
         <Route path="browse" element={<Browse />} />
         <Route path="cart" element={<Cart />} />
+        <Route path="order-confirmation" element={<OrderConfirmation />} />
         <Route path="restaurant/:id" element={<Restaurant />} />
       </Route>
     </Routes>

--- a/src/pages/Cart.jsx
+++ b/src/pages/Cart.jsx
@@ -1,8 +1,17 @@
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useCart } from '../context/CartContext';
 
 const Cart = () => {
-  const { cart, totalItems, totalPrice, updateItemQuantity, removeItem } = useCart();
+  const {
+    cart,
+    totalItems,
+    totalPrice,
+    updateItemQuantity,
+    removeItem,
+    clearCart,
+  } = useCart();
+  const navigate = useNavigate();
   const [address, setAddress] = useState('');
   const [instructions, setInstructions] = useState('');
   const [paymentMethod, setPaymentMethod] = useState('');
@@ -27,10 +36,10 @@ const Cart = () => {
   };
 
   const handleCheckout = () => {
-    // Front-end only confirmation
-    alert(
-      `Placing order using ${paymentMethod}\nAddress: ${address}\nInstructions: ${instructions}`
-    );
+    clearCart();
+    navigate('/order-confirmation', {
+      state: { address, totalPrice },
+    });
   };
 
   return (

--- a/src/pages/OrderConfirmation.jsx
+++ b/src/pages/OrderConfirmation.jsx
@@ -1,0 +1,24 @@
+import { Link, useLocation } from 'react-router-dom';
+
+const OrderConfirmation = () => {
+  const { state } = useLocation();
+  const address = state?.address || '';
+  const totalPrice = state?.totalPrice || 0;
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center text-center px-4 py-8">
+      <h1 className="text-3xl font-bold mb-4">Thank you for your order!</h1>
+      <p className="text-gray-700 mb-2">Your food will be delivered to:</p>
+      <p className="font-medium mb-4 whitespace-pre-line">{address}</p>
+      <p className="text-lg font-semibold mb-6">Total Paid: ₹{totalPrice}</p>
+      <Link
+        to="/"
+        className="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700"
+      >
+        Return Home
+      </Link>
+    </div>
+  );
+};
+
+export default OrderConfirmation;


### PR DESCRIPTION
## Summary
- add `OrderConfirmation` page to thank the user and show order details
- clear the cart and navigate to confirmation page after checkout
- include new route for order confirmation

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6854e3c72d14832086fc5fa642aafd6b