### PR TITLE
Setup GitHub Pages deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,38 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v2
+        with:
+          path: ./dist
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v2

--- a/404.html
+++ b/404.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Redirecting...</title>
+    <script>
+      // SPA fallback for GitHub Pages
+      (function() {
+        const redirect = sessionStorage.redirect;
+        if (redirect) {
+          sessionStorage.removeItem('redirect');
+          window.location.replace(redirect);
+        } else {
+          const path = location.pathname.replace(/\/quick-eats-react\/?/, '/');
+          sessionStorage.redirect = path + location.search + location.hash;
+          window.location.replace('/quick-eats-react/');
+        }
+      })();
+    </script>
+  </head>
+  <body>
+  </body>
+</html>

--- a/README.md
+++ b/README.md
@@ -28,3 +28,25 @@ Fix:
     
 Issue 2: Taiwind css not working
 Update index.css with @import "tailwindcss";
+
+## Deployment to GitHub Pages
+
+The project includes a GitHub Actions workflow that builds the Vite app and
+publishes the contents of the `dist` directory to GitHub Pages. Routing works
+thanks to a `404.html` file that redirects unknown paths back to the SPA.
+
+To deploy:
+
+1. Ensure the repository name matches the configured Vite `base` option:
+   `/quick-eats-react/`.
+2. Push changes to the `main` branch. The workflow will build the project and
+   automatically deploy to the `gh-pages` environment.
+
+If you need to run the build locally you can execute:
+
+```bash
+npm install
+npm run build
+```
+
+The static files will appear in the `dist` folder.

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,5 +3,8 @@ import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
+  // Base path is required so assets load correctly when hosted from
+  // a subdirectory like GitHub Pages.
+  base: '/quick-eats-react/',
   plugins: [react()],
 })


### PR DESCRIPTION
## Summary
- enable GitHub Pages deployment with GitHub Actions
- redirect unknown routes via `404.html`
- document deployment steps in README
- configure vite base path for GitHub Pages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855415148fc8320913317c041fb4928