### PR TITLE
Add cuisine filtering and new restaurants

### DIFF
--- a/src/components/CuisineChips.jsx
+++ b/src/components/CuisineChips.jsx
@@ -1,17 +1,25 @@
 import { cuisines } from "../data/cuisines";
 
-const CuisineChips = () => {
+const CuisineChips = ({ selectedCuisine, setSelectedCuisine }) => {
   return (
     <div className="overflow-x-auto w-full mt-4 px-4">
       <div className="flex gap-2 sm:gap-4 overflow-x-auto whitespace-nowrap px-4 pb-2">
-        {cuisines.map((item, index) => (
-          <button
-            key={index}
-            className="px-4 py-2 bg-gray-200 dark:bg-gray-800 text-gray-700 dark:text-gray-200 rounded-full hover:bg-red-600 hover:text-white transition-all"
-          >
-            {item}
-          </button>
-        ))}
+        {cuisines.map((item, index) => {
+          const active = selectedCuisine === item;
+          return (
+            <button
+              key={index}
+              onClick={() => setSelectedCuisine(item)}
+              className={`px-4 py-2 rounded-full transition-all ${
+                active
+                  ? "bg-red-600 text-white"
+                  : "bg-gray-200 dark:bg-gray-800 text-gray-700 dark:text-gray-200 hover:bg-red-600 hover:text-white"
+              }`}
+            >
+              {item}
+            </button>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/data/restaurants.js
+++ b/src/data/restaurants.js
@@ -108,5 +108,68 @@ export const restaurants = [
     price: "$$$",
     time: 25,
     image: "https://source.unsplash.com/400x300/?pizza"
+  },
+  {
+    id: 9,
+    name: "Dragon Wok",
+    cuisine: "Chinese",
+    rating: 4.4,
+    price: "$$",
+    time: 25,
+    image: "https://source.unsplash.com/400x300/?chinese-food"
+  },
+  {
+    id: 10,
+    name: "Burger Hub",
+    cuisine: "Fast Food",
+    rating: 4.2,
+    price: "$",
+    time: 15,
+    image: "https://source.unsplash.com/400x300/?burger"
+  },
+  {
+    id: 11,
+    name: "Taco Fiesta",
+    cuisine: "Mexican",
+    rating: 4.6,
+    price: "$$",
+    time: 20,
+    image: "https://source.unsplash.com/400x300/?tacos"
+  },
+  {
+    id: 12,
+    name: "Thai Spice",
+    cuisine: "Thai",
+    rating: 4.5,
+    price: "$$",
+    time: 25,
+    image: "https://source.unsplash.com/400x300/?thai-food"
+  },
+  {
+    id: 13,
+    name: "Sweet Treats",
+    cuisine: "Desserts",
+    rating: 4.8,
+    price: "$",
+    time: 15,
+    image: "https://source.unsplash.com/400x300/?dessert"
+  },
+  {
+    id: 14,
+    name: "Green Delight",
+    cuisine: "Healthy",
+    rating: 4.3,
+    price: "$$",
+    time: 20,
+    image: "https://source.unsplash.com/400x300/?salad"
+  },
+  {
+    id: 15,
+    name: "Dosa Corner",
+    cuisine: "South Indian",
+    rating: 4.6,
+    price: "$",
+    time: 20,
+    image: "https://source.unsplash.com/400x300/?dosa"
   }
 ];

--- a/src/pages/Browse.jsx
+++ b/src/pages/Browse.jsx
@@ -2,6 +2,7 @@ import RestaurantCard from '../components/RestaurantCard';
 import { useState } from "react";
 import { Link } from 'react-router-dom';
 import { restaurants } from '../data/restaurants';
+import { cuisines } from '../data/cuisines';
 
 const Browse = () => {
   const [selectedCuisine, setSelectedCuisine] = useState('All');
@@ -43,11 +44,16 @@ const filteredRestaurants = restaurants.filter(r =>
   <option value="time">Delivery Time (Fastest First)</option>
 </select>
       <div className="mb-6 flex flex-wrap gap-4">
-  <select value={selectedCuisine} onChange={e => setSelectedCuisine(e.target.value)} className="p-2 border rounded w-full sm:w-auto">
-    <option value="All">All Cuisines</option>
-    <option value="Indian">Indian</option>
-    <option value="Chinese">Chinese</option>
-    <option value="Italian">Italian</option>
+  <select
+    value={selectedCuisine}
+    onChange={e => setSelectedCuisine(e.target.value)}
+    className="p-2 border rounded w-full sm:w-auto"
+  >
+    {cuisines.map(c => (
+      <option key={c} value={c}>
+        {c === 'All' ? 'All Cuisines' : c}
+      </option>
+    ))}
   </select>
   <select value={minRating} onChange={e => setMinRating(Number(e.target.value))} className="p-2 border rounded w-full sm:w-auto">
     <option value="0">All Ratings</option>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -16,6 +16,7 @@ const Home = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [featuredRestaurants, setFeaturedRestaurants] = useState([]);
+  const [selectedCuisine, setSelectedCuisine] = useState("All");
 
   useEffect(() => {
     // Simulated fetch with try/catch
@@ -28,7 +29,10 @@ const Home = () => {
         await res.json();
 
         // Simulated restaurant objects
-        setFeaturedRestaurants(restaurants.slice(0, 3));
+        const filtered = restaurants.filter(
+          (r) => selectedCuisine === "All" || r.cuisine === selectedCuisine
+        );
+        setFeaturedRestaurants(filtered.slice(0, 3));
         setError(null);
       } catch (err) {
         setError(err.message);
@@ -38,7 +42,7 @@ const Home = () => {
     };
 
     fetchData();
-  }, []);
+  }, [selectedCuisine]);
   return (
     <>
       <motion.div
@@ -66,7 +70,10 @@ const Home = () => {
             </button>
           </div>
         </section>
-        <CuisineChips />
+        <CuisineChips
+          selectedCuisine={selectedCuisine}
+          setSelectedCuisine={setSelectedCuisine}
+        />
         <section className="mt-8 px-4">
           <h2 className="text-2xl font-bold mb-4">Featured Restaurants</h2>
           <div className="bg-white flex gap-4 overflow-x-auto pb-2 md:grid md:grid-cols-3 md:gap-6 md:overflow-visible">


### PR DESCRIPTION
## Summary
- extend restaurants data with more cuisines
- manage selected cuisine on the home page and filter featured restaurants
- allow selecting cuisine through `CuisineChips`
- reuse cuisines list inside Browse filters

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685632e6105c8320923a79bdad809cdc